### PR TITLE
SonarQube: add projectVersion to analysis

### DIFF
--- a/.github/workflows/dev-branch-pr-build-and-test-pipeline.yaml
+++ b/.github/workflows/dev-branch-pr-build-and-test-pipeline.yaml
@@ -41,7 +41,7 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-        run: mvn -B verify -Pdev org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.scm.provider=git -Dsonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml
+        run: mvn -B verify -Pdev org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectVersion=pr-${{ github.event.pull_request.number }} -Dsonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml
 
       - name: SonarQube Quality Gate check
         id: sonarqube-quality-gate-check


### PR DESCRIPTION
Added -Dsonar.projectVersion=pr-${{ github.event.pull_request.number }}.
This will simplify tracking of analyses at `Activity` tab.

<img width="685" alt="Screenshot 2023-12-25 at 22 00 05" src="https://github.com/Sunagatov/Iced-Latte/assets/20650874/fe4aea89-ea0c-4e61-9396-faa4278ef50d">
