### PR TITLE
fix: #273 max length of "First Name" and "Last Name" to 128 characters

### DIFF
--- a/src/main/resources/db/changelog/version-1.0/28.07.2023.part5.create-user-details-table.sql
+++ b/src/main/resources/db/changelog/version-1.0/28.07.2023.part5.create-user-details-table.sql
@@ -1,8 +1,8 @@
 CREATE TABLE user_details
 (
     id                      UUID         NOT NULL PRIMARY KEY,
-    first_name              VARCHAR(55)  NOT NULL,
-    last_name               VARCHAR(55)  NOT NULL,
+    first_name              VARCHAR(128)  NOT NULL,
+    last_name               VARCHAR(128)  NOT NULL,
     birth_date              DATE,
     phone_number            VARCHAR(25),
     stripe_customer_token   VARCHAR(64) UNIQUE,


### PR DESCRIPTION
Modified changelog for create-user-details-table to accept 128 char value in the database.