### PR TITLE
[Issue #275] Fix. Error response of Update User API.

### DIFF
--- a/src/main/java/com/zufar/icedlatte/user/endpoint/UserEndpoint.java
+++ b/src/main/java/com/zufar/icedlatte/user/endpoint/UserEndpoint.java
@@ -15,6 +15,7 @@ import com.zufar.icedlatte.user.api.UpdateUserOperationPerformer;
 import com.zufar.icedlatte.filestorage.file.FileDeleter;
 import com.zufar.icedlatte.user.api.avatar.UserAvatarLinkProvider;
 import com.zufar.icedlatte.user.api.avatar.UserAvatarUploader;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -68,7 +69,7 @@ public class UserEndpoint implements com.zufar.icedlatte.openapi.user.api.UserAp
 
     @Override
     @PutMapping
-    public ResponseEntity<UserDto> editUserById(UpdateUserAccountRequest updateUserAccountRequest) {
+    public ResponseEntity<UserDto> editUserById(@Valid @RequestBody UpdateUserAccountRequest updateUserAccountRequest) {
         UUID userId = securityPrincipalProvider.getUserId();
         log.info("Received the request to edit the User with userId - {}.", userId);
         UserDto updatedUserDto = updateUserOperationPerformer.updateUser(updateUserAccountRequest);

--- a/src/main/java/com/zufar/icedlatte/user/exception/handler/UserExceptionHandler.java
+++ b/src/main/java/com/zufar/icedlatte/user/exception/handler/UserExceptionHandler.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -46,5 +47,18 @@ public class UserExceptionHandler {
         log.warn("Handle user's invalid old password exception: failed: message: {}, debugMessage: {}",
                 apiErrorResponse.message(), errorDebugMessageCreator.buildErrorDebugMessage(exception));
         return apiErrorResponse;
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ApiErrorResponse handleValidationExceptions(MethodArgumentNotValidException ex) {
+        StringBuilder errorMessage = new StringBuilder();
+        ex.getBindingResult().getFieldErrors().forEach(error -> {
+            if (errorMessage.length() > 0) {
+                errorMessage.append(" and ");
+            }
+            errorMessage.append(error.getDefaultMessage());
+        });
+        return apiErrorResponseCreator.buildResponse(errorMessage.toString(), HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/resources/api-specs/user-openapi.yaml
+++ b/src/main/resources/api-specs/user-openapi.yaml
@@ -221,16 +221,15 @@ components:
     UpdateUserAccountRequest:
       type: "object"
       description: "A user profile object details to update"
-      required:
-        - firstName
-        - lastName
       properties:
         firstName:
           type: "string"
           description: "The first name of the user"
+          x-field-extra-annotation: "@jakarta.validation.constraints.NotNull(message = \"First name is the mandatory attribute\")"
         lastName:
           type: "string"
           description: "The last name of the user"
+          x-field-extra-annotation: "@jakarta.validation.constraints.NotNull(message = \"Last name is the mandatory attribute\")"
         birthDate:
           type: "string"
           description: "The birth date of the user"


### PR DESCRIPTION
1. Updated the user-openapi to enable custom error messages for required fields.
2. Added an exceptional handler for the expected error message in the api response.
<img width="1172" alt="Screenshot 2024-06-11 at 12 17 13 AM" src="https://github.com/Sunagatov/Iced-Latte/assets/106912105/f2acd33b-2694-4b93-9a0b-8ab6493c5a90">
<img width="1137" alt="Screenshot 2024-06-11 at 12 22 41 AM" src="https://github.com/Sunagatov/Iced-Latte/assets/106912105/c84ae3e4-52c6-4d65-99cd-9cfc674fb630">
