### PR TITLE
GET product reviews request with an invalid value of param "product_rating" the system returns all product reviews.

### DIFF
--- a/src/main/java/com/zufar/icedlatte/review/endpoint/ProductReviewEndpoint.java
+++ b/src/main/java/com/zufar/icedlatte/review/endpoint/ProductReviewEndpoint.java
@@ -74,8 +74,8 @@ public class ProductReviewEndpoint implements com.zufar.icedlatte.openapi.produc
                                                                                               @RequestParam(name = "sort_attribute", defaultValue = "createdAt") final String sortAttribute,
                                                                                               @RequestParam(name = "sort_direction", defaultValue = "desc") final String sortDirection,
                                                                                               @RequestParam(name = "product_ratings", required = false) List<Integer> productRatings) {
-        log.info("Received the request to get reviews and ratings for the product with the productId = '{}' and with the next pagination and sorting attributes: pageNumber - {}, pageSize - {}, sort_attribute - {}, sort_direction - {}",
-                productId, pageNumber, pageSize, sortAttribute, sortDirection);
+        log.info("Received the request to get reviews and ratings for the product with the productId = '{}' and with the next pagination and sorting attributes: pageNumber - {}, pageSize - {}, sort_attribute - {}, sort_direction - {}, productRatings - {}",
+                productId, pageNumber, pageSize, sortAttribute, sortDirection, productRatings);
         Pageable pageable = createPageableObject(pageNumber, pageSize, sortAttribute, sortDirection);
         getReviewsRequestValidator.validate(pageNumber, pageSize, sortAttribute, sortDirection, productRatings);
         ProductReviewsAndRatingsWithPagination reviewsPaginationDto = productReviewsProvider.getProductReviews(productId, pageable, productRatings);

--- a/src/main/java/com/zufar/icedlatte/review/validator/GetReviewsRequestValidator.java
+++ b/src/main/java/com/zufar/icedlatte/review/validator/GetReviewsRequestValidator.java
@@ -38,6 +38,10 @@ public class GetReviewsRequestValidator {
 
     private StringBuilder validateProductRatingsParameter(final List<Integer> productRatings) {
         final StringBuilder errorMessages = new StringBuilder();
+        if (productRatings == null || productRatings.isEmpty()) {
+            String errorMessage = String.format("product's rating is required. Allowed 'productRating' values are '%s'.", ALLOWED_PRODUCT_RATING_VALUES);
+            errorMessages.append(createErrorMessage(errorMessage));
+        }
         if ((productRatings != null && productRatings.stream().anyMatch(Objects::isNull))
                 || (productRatings != null && !ALLOWED_PRODUCT_RATING_VALUES.containsAll(productRatings))) {
             String errorMessage = String.format("Some values of this product's rating list = '%s' are incorrect. Allowed 'productRating' values are '%s'.",

--- a/src/main/java/com/zufar/icedlatte/review/validator/GetReviewsRequestValidator.java
+++ b/src/main/java/com/zufar/icedlatte/review/validator/GetReviewsRequestValidator.java
@@ -38,7 +38,7 @@ public class GetReviewsRequestValidator {
 
     private StringBuilder validateProductRatingsParameter(final List<Integer> productRatings) {
         final StringBuilder errorMessages = new StringBuilder();
-        if (productRatings == null || productRatings.isEmpty()) {
+        if (productRatings == null) {
             String errorMessage = String.format("product's rating is required. Allowed 'productRating' values are '%s'.", ALLOWED_PRODUCT_RATING_VALUES);
             errorMessages.append(createErrorMessage(errorMessage));
         }

--- a/src/test/java/com/zufar/icedlatte/review/endpoint/ProductReviewEndpointTest.java
+++ b/src/test/java/com/zufar/icedlatte/review/endpoint/ProductReviewEndpointTest.java
@@ -102,34 +102,6 @@ class ProductReviewEndpointTest {
     }
 
     @Test
-    @DisplayName("Should fetch reviews and ratings with default pagination and sorting for unauthorized user")
-    void shouldFetchReviewsAndRatingsWithDefaultPaginationAndSortingForAnonymous() {
-        // No authorization is required
-        specification = given()
-                .log().all(true)
-                .port(port)
-                .basePath(ProductReviewEndpoint.PRODUCT_REVIEW_URL)
-                .contentType(ContentType.JSON)
-                .accept(ContentType.JSON);
-
-        Response response = given(specification)
-                .get("/{productId}/reviews", AMERICANO_ID);
-
-        assertRestApiBodySchemaResponse(response, HttpStatus.OK, REVIEWS_WITH_RATINGS_RESPONSE_SCHEMA)
-                .body("totalElements", equalTo(3))
-                .body("totalPages", equalTo(1))
-                .body("reviewsWithRatings[0].productRating", equalTo(5))
-                .body("reviewsWithRatings[0].text", startsWith(START_OF_REVIEW_FOR_AMERICANO))
-                .body("reviewsWithRatings[0].userName", equalTo("John"))
-                .body("reviewsWithRatings[1].productRating", equalTo(3))
-                .body("reviewsWithRatings[1].text", startsWith(START_OF_REVIEW_FOR_AMERICANO))
-                .body("reviewsWithRatings[1].userName", equalTo("Jane"))
-                .body("reviewsWithRatings[2].productRating", equalTo(1))
-                .body("reviewsWithRatings[2].text", startsWith(START_OF_REVIEW_FOR_AMERICANO))
-                .body("reviewsWithRatings[2].userName", equalTo("Michael"));
-    }
-
-    @Test
     @DisplayName("Should like review successfully and return review object")
     void shouldLikeReviewSuccessfully() {
         String body = "{\"isLike\": true}";
@@ -183,6 +155,24 @@ class ProductReviewEndpointTest {
                 .body("ratingMap.star3", equalTo(1))
                 .body("ratingMap.star4", equalTo(0))
                 .body("ratingMap.star5", equalTo(0));
+    }
+
+
+    @Test
+    @DisplayName("Reviews and ratings with default pagination and sorting for unauthorized user. Should return 400 Bad Request")
+    void shouldReturnBadRequestForDefaultPaginationAndSortingForAnonymous() {
+        // No authorization is required
+        specification = given()
+                .log().all(true)
+                .port(port)
+                .basePath(ProductReviewEndpoint.PRODUCT_REVIEW_URL)
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON);
+
+        Response response = given(specification)
+                .get("/{productId}/reviews", AMERICANO_ID);
+
+        assertRestApiBadRequestResponse(response, FAILED_REVIEW_SCHEMA);
     }
 
     @Test


### PR DESCRIPTION

## Problem 
If "%"  is pass then system doesn't receive it making `List<Integer> productRating ` null, that passes all the validation and display all the relevant records.[Link](https://github.com/Sunagatov/Iced-Latte/issues/329)

## Proposed Solution
Added a validation for null `List<Integer> productRating ` so that user get the error message to add rating.
If we want to pass actual "%" then the correct way is passing `%25`. FYI system request that request.

## Ripple Effect
Adding that check will change the non required productRating as it is a required field now.

## Problem in Hand
How backend system will distinguished 
CASE1: productRating = %
CASE2: (productRating not sent) 
as for that system both are null.  