### PR TITLE
Removed null check for GetReviewsRequestValidator

### DIFF
--- a/src/main/java/com/zufar/icedlatte/review/validator/GetReviewsRequestValidator.java
+++ b/src/main/java/com/zufar/icedlatte/review/validator/GetReviewsRequestValidator.java
@@ -38,10 +38,6 @@ public class GetReviewsRequestValidator {
 
     private StringBuilder validateProductRatingsParameter(final List<Integer> productRatings) {
         final StringBuilder errorMessages = new StringBuilder();
-        if (productRatings == null) {
-            String errorMessage = String.format("product's rating is required. Allowed 'productRating' values are '%s'.", ALLOWED_PRODUCT_RATING_VALUES);
-            errorMessages.append(createErrorMessage(errorMessage));
-        }
         if ((productRatings != null && productRatings.stream().anyMatch(Objects::isNull))
                 || (productRatings != null && !ALLOWED_PRODUCT_RATING_VALUES.containsAll(productRatings))) {
             String errorMessage = String.format("Some values of this product's rating list = '%s' are incorrect. Allowed 'productRating' values are '%s'.",

--- a/src/test/java/com/zufar/icedlatte/review/endpoint/ProductReviewEndpointTest.java
+++ b/src/test/java/com/zufar/icedlatte/review/endpoint/ProductReviewEndpointTest.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 import static com.zufar.icedlatte.test.config.RestAssertion.assertRestApiBadRequestResponse;
 import static com.zufar.icedlatte.test.config.RestAssertion.assertRestApiBodySchemaResponse;
 import static com.zufar.icedlatte.test.config.RestAssertion.assertRestApiNotFoundResponse;
+import static com.zufar.icedlatte.test.config.RestAssertion.assertRestApiOkResponse;
 import static com.zufar.icedlatte.test.config.RestUtils.getJwtToken;
 import static com.zufar.icedlatte.test.config.RestUtils.getRequestBody;
 import static io.restassured.RestAssured.given;
@@ -159,8 +160,8 @@ class ProductReviewEndpointTest {
 
 
     @Test
-    @DisplayName("Reviews and ratings with default pagination and sorting for unauthorized user. Should return 400 Bad Request")
-    void shouldReturnBadRequestForDefaultPaginationAndSortingForAnonymous() {
+    @DisplayName("Reviews and ratings with default pagination and sorting for unauthorized user. Should return 200 OK")
+    void shouldSuccessfullyReturnReviewsForDefaultPaginationAndSortingForAnonymous() {
         // No authorization is required
         specification = given()
                 .log().all(true)
@@ -172,7 +173,7 @@ class ProductReviewEndpointTest {
         Response response = given(specification)
                 .get("/{productId}/reviews", AMERICANO_ID);
 
-        assertRestApiBadRequestResponse(response, FAILED_REVIEW_SCHEMA);
+        assertRestApiOkResponse(response, REVIEWS_WITH_RATINGS_RESPONSE_SCHEMA);
     }
 
     @Test


### PR DESCRIPTION
**1. Task's name:** 

Allow empty list with rating values
![telegram-cloud-photo-size-2-5307722599192715169-y](https://github.com/user-attachments/assets/fef13a0a-919a-4b3f-9c2e-c38b691b135f)

**2. Developer's full name:**

Anna Striganova

**3. Changes:**

- removed `null` check for ratings list from validator


