### PR TITLE
fixes: #269

### DIFF
--- a/src/main/java/com/zufar/icedlatte/review/exception/InvalidProductReviewTextException.java
+++ b/src/main/java/com/zufar/icedlatte/review/exception/InvalidProductReviewTextException.java
@@ -1,0 +1,7 @@
+package com.zufar.icedlatte.review.exception;
+
+public class InvalidProductReviewTextException extends RuntimeException {
+    public InvalidProductReviewTextException() {
+        super("The Product Review Text Is Invalid.");
+    }
+}

--- a/src/main/java/com/zufar/icedlatte/review/exception/handler/ProductReviewExceptionHandler.java
+++ b/src/main/java/com/zufar/icedlatte/review/exception/handler/ProductReviewExceptionHandler.java
@@ -5,6 +5,7 @@ import com.zufar.icedlatte.common.exception.handler.ApiErrorResponseCreator;
 import com.zufar.icedlatte.common.exception.handler.ErrorDebugMessageCreator;
 import com.zufar.icedlatte.review.exception.DeniedProductReviewCreationException;
 import com.zufar.icedlatte.review.exception.DeniedProductReviewDeletionException;
+import com.zufar.icedlatte.review.exception.InvalidProductReviewTextException;
 import com.zufar.icedlatte.review.exception.EmptyProductReviewException;
 import com.zufar.icedlatte.review.exception.GetReviewsBadRequestException;
 import com.zufar.icedlatte.review.exception.ProductIdsAreNotMatchException;
@@ -30,6 +31,17 @@ public class ProductReviewExceptionHandler {
         ApiErrorResponse apiErrorResponse = apiErrorResponseCreator.buildResponse(exception, HttpStatus.BAD_REQUEST);
 
         log.warn("Handle unsupported review format exception: failed: message: {}, debugMessage: {}.",
+                apiErrorResponse.message(), errorDebugMessageCreator.buildErrorDebugMessage(exception));
+
+        return apiErrorResponse;
+    }
+
+    @ExceptionHandler(InvalidProductReviewTextException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ApiErrorResponse handleInvalidProductReviewTextException(final InvalidProductReviewTextException exception) {
+        ApiErrorResponse apiErrorResponse = apiErrorResponseCreator.buildResponse(exception, HttpStatus.BAD_REQUEST);
+
+        log.warn("Handle invalid product review text exception: failed: message: {}, debugMessage: {}.",
                 apiErrorResponse.message(), errorDebugMessageCreator.buildErrorDebugMessage(exception));
 
         return apiErrorResponse;

--- a/src/main/java/com/zufar/icedlatte/review/validator/ProductReviewValidator.java
+++ b/src/main/java/com/zufar/icedlatte/review/validator/ProductReviewValidator.java
@@ -8,6 +8,7 @@ import com.zufar.icedlatte.review.exception.EmptyProductReviewException;
 import com.zufar.icedlatte.review.exception.ProductIdsAreNotMatchException;
 import com.zufar.icedlatte.review.exception.ProductNotFoundForReviewException;
 import com.zufar.icedlatte.review.exception.ProductReviewNotFoundException;
+import com.zufar.icedlatte.review.exception.InvalidProductReviewTextException;
 import com.zufar.icedlatte.review.repository.ProductReviewRepository;
 import com.zufar.icedlatte.security.api.SecurityPrincipalProvider;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Slf4j
 @Service
@@ -32,6 +35,11 @@ public class ProductReviewValidator {
     public void validateReviewText(final String productReviewText) {
         if (productReviewText.trim().isEmpty()) {
             throw new EmptyProductReviewException();
+        }
+        Pattern p = Pattern.compile("[^a-zA-Z0-9\\u00C0-\\u017F.,! ]");
+        Matcher matcher = p.matcher(productReviewText);
+        if(matcher.find()) {
+            throw new InvalidProductReviewTextException();
         }
     }
 


### PR DESCRIPTION
### Pull Request: Fix Input Validation for Text Field

**Description:**

This PR fixes the validation issue in the input text field, where it was previously accepting special characters, non-Latin letters, and links that were not part of the defined allowed character set.

**Changes:**
- The input field is now restricted to accept only **extended Latin letters**, **digits**, and the following **symbols**: `.`, `,`, `!`.
- Any input containing **non-Latin characters** or the `-` special character is now properly rejected.

**Reasoning:**

This fix ensures the input complies with the review requirements, which specify the allowed characters for the field. The changes prevent invalid input while maintaining flexibility for standard text usage.

**Related Issue:**
- Fixes #269
