### PR TITLE
Add product-specific RAG assistant endpoint

### DIFF
--- a/docs/ai/product-rag.md
+++ b/docs/ai/product-rag.md
@@ -1,0 +1,79 @@
+# Product RAG endpoint
+
+This document describes the first lightweight Retrieval-Augmented Generation (RAG) slice for the backend.
+
+## What it does
+
+It adds a product-specific AI endpoint that:
+
+- loads the target product
+- retrieves grounded context from that product's:
+  - description
+  - AI summary (if present)
+  - customer reviews
+- ranks the most relevant context snippets for the user question
+- sends only that retrieved context to the LLM
+- returns both the answer and the retrieved sources
+
+This is intentionally a **small learning-friendly RAG slice** rather than a full site-wide chatbot.
+
+## Endpoint
+
+```http
+POST /api/v1/products/{productId}/rag/ask
+```
+
+## Request body
+
+```json
+{
+  "question": "Does this coffee taste chocolatey?"
+}
+```
+
+## Example response
+
+```json
+{
+  "productId": "7aef9ecb-7a24-4f38-a8a2-85bf86acaa8c",
+  "productName": "Brazilian Espresso Beans",
+  "question": "Does this coffee taste chocolatey?",
+  "answer": "Yes. The retrieved context mentions chocolate notes in both the product details and customer feedback.",
+  "sources": [
+    {
+      "sourceType": "PRODUCT_DETAILS",
+      "sourceLabel": "Product details",
+      "excerpt": "Product name: Brazilian Espresso Beans. Description: A rich medium roast with chocolate, caramel, and hazelnut notes...",
+      "score": 56.0
+    },
+    {
+      "sourceType": "REVIEW",
+      "sourceLabel": "Review #1 — rating 5/5",
+      "excerpt": "Rating: 5/5. Review text: Very chocolatey, smooth, and easy to drink.",
+      "score": 27.0
+    }
+  ]
+}
+```
+
+## Enablement
+
+This endpoint is available when:
+
+- `AI_ENABLED=true`
+- a working AI API key and base URL are configured
+
+Optional tuning knobs can be provided without changing code:
+
+- `AI_RAG_MAX_CONTEXT_ITEMS` via `ai.rag.max-context-items` property placeholder support
+- `AI_RAG_MAX_CONTEXT_CHARS_PER_ITEM` via `ai.rag.max-context-chars-per-item` property placeholder support
+
+## Why this approach
+
+This first version keeps the implementation simple and easy to understand:
+
+- no extra vector database setup
+- no new infrastructure requirement
+- context retrieval is transparent because the API returns the snippets it used
+
+That makes it a good base for later upgrades such as embeddings, pgvector, semantic search, or a frontend chat UI.

--- a/src/main/java/com/zufar/icedlatte/ai/rag/DefaultProductRagService.java
+++ b/src/main/java/com/zufar/icedlatte/ai/rag/DefaultProductRagService.java
@@ -1,0 +1,86 @@
+package com.zufar.icedlatte.ai.rag;
+
+import com.zufar.icedlatte.ai.rag.dto.ProductRagAskResponse;
+import com.zufar.icedlatte.ai.rag.dto.ProductRagSourceDto;
+import com.zufar.icedlatte.product.exception.ProductNotFoundException;
+import com.zufar.icedlatte.product.repository.ProductInfoRepository;
+import com.zufar.icedlatte.review.repository.ProductReviewRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "ai.enabled", havingValue = "true")
+class DefaultProductRagService implements ProductRagService {
+
+    private static final String FALLBACK_ANSWER = "AI answer is temporarily unavailable for this product question.";
+
+    private final ProductInfoRepository productInfoRepository;
+    private final ProductReviewRepository productReviewRepository;
+    private final ProductRagContextRetriever productRagContextRetriever;
+    private final ProductRagAiService productRagAiService;
+
+    @Override
+    @Transactional(readOnly = true)
+    public ProductRagAskResponse ask(UUID productId, String question) {
+        var product = productInfoRepository.findById(productId)
+                .orElseThrow(() -> new ProductNotFoundException(productId));
+
+        var reviews = productReviewRepository.findAllByProductId(productId);
+        var retrievedContext = productRagContextRetriever.retrieve(product, reviews, question);
+        var prompt = buildPrompt(product.getName(), product.getBrandName(), product.getSellerName(), question, retrievedContext);
+
+        String answer;
+        try {
+            answer = productRagAiService.answer(prompt);
+        } catch (Exception exception) {
+            log.warn("product.rag.answer.unavailable: productId={} cause={}", productId, exception.getMessage());
+            answer = FALLBACK_ANSWER;
+        }
+
+        var sources = retrievedContext.stream()
+                .map(context -> new ProductRagSourceDto(
+                        context.sourceType(),
+                        context.sourceLabel(),
+                        context.content(),
+                        context.score()))
+                .toList();
+
+        return new ProductRagAskResponse(productId, product.getName(), question, answer, sources);
+    }
+
+    private String buildPrompt(String productName,
+                               String brandName,
+                               String sellerName,
+                               String question,
+                               java.util.List<RetrievedProductContext> retrievedContext) {
+        var contextBlock = retrievedContext.stream()
+                .map(RetrievedProductContext::promptBlock)
+                .collect(Collectors.joining("\n\n"));
+
+        return """
+                Product name: %s
+                Brand: %s
+                Seller: %s
+
+                User question:
+                %s
+
+                Retrieved context:
+                %s
+
+                Instructions:
+                - Answer only from the retrieved context above.
+                - If the context is not enough, say that clearly.
+                - Do not invent missing product facts.
+                - Keep the answer concise and practical.
+                """.formatted(productName, brandName, sellerName, question, contextBlock);
+    }
+}

--- a/src/main/java/com/zufar/icedlatte/ai/rag/ProductRagAiService.java
+++ b/src/main/java/com/zufar/icedlatte/ai/rag/ProductRagAiService.java
@@ -1,0 +1,16 @@
+package com.zufar.icedlatte.ai.rag;
+
+import dev.langchain4j.service.SystemMessage;
+import dev.langchain4j.service.UserMessage;
+
+interface ProductRagAiService {
+
+    @SystemMessage("""
+            You are a product assistant for the Iced Latte coffee marketplace.
+            Answer only from the retrieved product context you receive.
+            If the context is insufficient, say clearly that the answer is not available from the provided context.
+            Do not invent facts, specifications, prices, ingredients, or review sentiment.
+            Keep the answer practical and concise.
+            """)
+    String answer(@UserMessage String prompt);
+}

--- a/src/main/java/com/zufar/icedlatte/ai/rag/ProductRagConfig.java
+++ b/src/main/java/com/zufar/icedlatte/ai/rag/ProductRagConfig.java
@@ -1,0 +1,19 @@
+package com.zufar.icedlatte.ai.rag;
+
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import dev.langchain4j.service.AiServices;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty(name = "ai.enabled", havingValue = "true")
+class ProductRagConfig {
+
+    @Bean
+    ProductRagAiService productRagAiService(OpenAiChatModel model) {
+        return AiServices.builder(ProductRagAiService.class)
+                .chatModel(model)
+                .build();
+    }
+}

--- a/src/main/java/com/zufar/icedlatte/ai/rag/ProductRagContextRetriever.java
+++ b/src/main/java/com/zufar/icedlatte/ai/rag/ProductRagContextRetriever.java
@@ -1,0 +1,135 @@
+package com.zufar.icedlatte.ai.rag;
+
+import com.zufar.icedlatte.product.entity.ProductInfo;
+import com.zufar.icedlatte.review.entity.ProductReview;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+class ProductRagContextRetriever {
+
+    private static final Set<String> STOP_WORDS = Set.of(
+            "the", "and", "for", "with", "that", "this", "from", "into", "about", "your", "their",
+            "does", "what", "when", "where", "which", "have", "has", "had", "are", "was", "were",
+            "but", "not", "too", "can", "how", "you", "its", "they", "them", "than", "then"
+    );
+
+    private final int maxContextItems;
+    private final int maxContextCharsPerItem;
+
+    ProductRagContextRetriever(
+            @Value("${ai.rag.max-context-items:5}") int maxContextItems,
+            @Value("${ai.rag.max-context-chars-per-item:500}") int maxContextCharsPerItem) {
+        this.maxContextItems = maxContextItems;
+        this.maxContextCharsPerItem = maxContextCharsPerItem;
+    }
+
+    List<RetrievedProductContext> retrieve(ProductInfo product, List<ProductReview> reviews, String question) {
+        var questionTokens = tokenize(question);
+        var candidates = new ArrayList<RetrievedProductContext>();
+
+        candidates.add(buildProductDetailsContext(product, question, questionTokens));
+
+        if (StringUtils.isNotBlank(product.getAiSummary())) {
+            candidates.add(buildContext(
+                    "PRODUCT_AI_SUMMARY",
+                    "Product AI summary",
+                    product.getAiSummary(),
+                    question,
+                    questionTokens,
+                    30.0
+            ));
+        }
+
+        var sortedReviews = reviews.stream()
+                .sorted(Comparator
+                        .comparingInt((ProductReview review) -> review.getLikesCount() == null ? 0 : review.getLikesCount())
+                        .reversed()
+                        .thenComparing(ProductReview::getCreatedAt, Comparator.nullsLast(Comparator.reverseOrder())))
+                .limit(20)
+                .toList();
+
+        for (int i = 0; i < sortedReviews.size(); i++) {
+            var review = sortedReviews.get(i);
+            var label = "Review #" + (i + 1) + " — rating " + review.getProductRating() + "/5";
+            var content = "Rating: " + review.getProductRating() + "/5. Review text: " + review.getText();
+            candidates.add(buildContext("REVIEW", label, content, question, questionTokens, 10.0));
+        }
+
+        return candidates.stream()
+                .filter(candidate -> StringUtils.isNotBlank(candidate.content()))
+                .sorted(Comparator
+                        .comparingDouble(RetrievedProductContext::score)
+                        .reversed()
+                        .thenComparing(RetrievedProductContext::sourceLabel))
+                .limit(maxContextItems)
+                .map(candidate -> candidate.truncatedTo(maxContextCharsPerItem))
+                .toList();
+    }
+
+    private RetrievedProductContext buildProductDetailsContext(ProductInfo product, String question, Set<String> questionTokens) {
+        var details = String.format(
+                "Product name: %s. Description: %s. Brand: %s. Seller: %s. Origin country: %s. Average rating: %s. Reviews count: %s.",
+                product.getName(),
+                product.getDescription(),
+                product.getBrandName(),
+                product.getSellerName(),
+                product.getOriginCountry(),
+                product.getAverageRating(),
+                product.getReviewsCount()
+        );
+        return buildContext("PRODUCT_DETAILS", "Product details", details, question, questionTokens, 40.0);
+    }
+
+    private RetrievedProductContext buildContext(String sourceType,
+                                                 String sourceLabel,
+                                                 String content,
+                                                 String question,
+                                                 Set<String> questionTokens,
+                                                 double baseScore) {
+        var score = score(question, questionTokens, content, baseScore);
+        return new RetrievedProductContext(sourceType, sourceLabel, content, score);
+    }
+
+    private double score(String question, Set<String> questionTokens, String candidateText, double baseScore) {
+        var normalizedQuestion = StringUtils.defaultString(question).toLowerCase(Locale.ROOT).trim();
+        var candidateTokens = tokenize(candidateText);
+
+        var overlap = questionTokens.stream()
+                .filter(candidateTokens::contains)
+                .count();
+
+        var score = baseScore + (overlap * 15.0);
+        var loweredCandidate = StringUtils.defaultString(candidateText).toLowerCase(Locale.ROOT);
+
+        if (StringUtils.isNotBlank(normalizedQuestion) && loweredCandidate.contains(normalizedQuestion)) {
+            score += 25.0;
+        }
+
+        for (var token : questionTokens) {
+            if (loweredCandidate.contains(token)) {
+                score += 1.0;
+            }
+        }
+
+        return score;
+    }
+
+    private Set<String> tokenize(String text) {
+        return Arrays.stream(StringUtils.defaultString(text).toLowerCase(Locale.ROOT).split("[^a-z0-9]+"))
+                .filter(StringUtils::isNotBlank)
+                .filter(token -> token.length() > 2)
+                .filter(token -> !STOP_WORDS.contains(token))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+}

--- a/src/main/java/com/zufar/icedlatte/ai/rag/ProductRagService.java
+++ b/src/main/java/com/zufar/icedlatte/ai/rag/ProductRagService.java
@@ -1,0 +1,10 @@
+package com.zufar.icedlatte.ai.rag;
+
+import com.zufar.icedlatte.ai.rag.dto.ProductRagAskResponse;
+
+import java.util.UUID;
+
+public interface ProductRagService {
+
+    ProductRagAskResponse ask(UUID productId, String question);
+}

--- a/src/main/java/com/zufar/icedlatte/ai/rag/RetrievedProductContext.java
+++ b/src/main/java/com/zufar/icedlatte/ai/rag/RetrievedProductContext.java
@@ -1,0 +1,16 @@
+package com.zufar.icedlatte.ai.rag;
+
+record RetrievedProductContext(String sourceType, String sourceLabel, String content, double score) {
+
+    RetrievedProductContext truncatedTo(int maxChars) {
+        if (content == null || content.length() <= maxChars || maxChars < 4) {
+            return this;
+        }
+        var shortened = content.substring(0, maxChars - 3).stripTrailing() + "...";
+        return new RetrievedProductContext(sourceType, sourceLabel, shortened, score);
+    }
+
+    String promptBlock() {
+        return "[" + sourceLabel + "]\n" + content;
+    }
+}

--- a/src/main/java/com/zufar/icedlatte/ai/rag/dto/ProductRagAskRequest.java
+++ b/src/main/java/com/zufar/icedlatte/ai/rag/dto/ProductRagAskRequest.java
@@ -1,0 +1,11 @@
+package com.zufar.icedlatte.ai.rag.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ProductRagAskRequest(
+        @NotBlank(message = "question must not be blank")
+        @Size(max = 500, message = "question must not exceed 500 characters")
+        String question
+) {
+}

--- a/src/main/java/com/zufar/icedlatte/ai/rag/dto/ProductRagAskResponse.java
+++ b/src/main/java/com/zufar/icedlatte/ai/rag/dto/ProductRagAskResponse.java
@@ -1,0 +1,13 @@
+package com.zufar.icedlatte.ai.rag.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+public record ProductRagAskResponse(
+        UUID productId,
+        String productName,
+        String question,
+        String answer,
+        List<ProductRagSourceDto> sources
+) {
+}

--- a/src/main/java/com/zufar/icedlatte/ai/rag/dto/ProductRagSourceDto.java
+++ b/src/main/java/com/zufar/icedlatte/ai/rag/dto/ProductRagSourceDto.java
@@ -1,0 +1,9 @@
+package com.zufar.icedlatte.ai.rag.dto;
+
+public record ProductRagSourceDto(
+        String sourceType,
+        String sourceLabel,
+        String excerpt,
+        double score
+) {
+}

--- a/src/main/java/com/zufar/icedlatte/ai/rag/endpoint/ProductRagEndpoint.java
+++ b/src/main/java/com/zufar/icedlatte/ai/rag/endpoint/ProductRagEndpoint.java
@@ -1,0 +1,39 @@
+package com.zufar.icedlatte.ai.rag.endpoint;
+
+import com.zufar.icedlatte.ai.rag.ProductRagService;
+import com.zufar.icedlatte.ai.rag.dto.ProductRagAskRequest;
+import com.zufar.icedlatte.ai.rag.dto.ProductRagAskResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@Slf4j
+@RestController
+@Validated
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "ai.enabled", havingValue = "true")
+@RequestMapping(ProductRagEndpoint.PRODUCT_RAG_URL)
+public class ProductRagEndpoint {
+
+    public static final String PRODUCT_RAG_URL = "/api/v1/products/{productId}/rag";
+
+    private final ProductRagService productRagService;
+
+    @PostMapping("/ask")
+    public ResponseEntity<ProductRagAskResponse> askQuestion(
+            @PathVariable UUID productId,
+            @Valid @RequestBody ProductRagAskRequest request) {
+        log.info("product.rag.ask: productId={} questionLength={}", productId, request.question().length());
+        return ResponseEntity.ok(productRagService.ask(productId, request.question()));
+    }
+}

--- a/src/test/java/com/zufar/icedlatte/ai/rag/DefaultProductRagServiceTest.java
+++ b/src/test/java/com/zufar/icedlatte/ai/rag/DefaultProductRagServiceTest.java
@@ -1,0 +1,81 @@
+package com.zufar.icedlatte.ai.rag;
+
+import com.zufar.icedlatte.product.entity.ProductInfo;
+import com.zufar.icedlatte.product.exception.ProductNotFoundException;
+import com.zufar.icedlatte.product.repository.ProductInfoRepository;
+import com.zufar.icedlatte.review.repository.ProductReviewRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DefaultProductRagService unit tests")
+class DefaultProductRagServiceTest {
+
+    @Mock
+    private ProductInfoRepository productInfoRepository;
+
+    @Mock
+    private ProductReviewRepository productReviewRepository;
+
+    @Mock
+    private ProductRagContextRetriever productRagContextRetriever;
+
+    @Mock
+    private ProductRagAiService productRagAiService;
+
+    @InjectMocks
+    private DefaultProductRagService service;
+
+    @Test
+    @DisplayName("ask: returns grounded answer with retrieved sources")
+    void ask_success_returnsAnswerAndSources() {
+        var productId = UUID.randomUUID();
+        var product = new ProductInfo();
+        product.setId(productId);
+        product.setName("Colombia Filter Roast");
+        product.setBrandName("Iced Latte Roasters");
+        product.setSellerName("Iced Latte");
+
+        var retrievedContext = List.of(
+                new RetrievedProductContext("PRODUCT_DETAILS", "Product details", "Chocolate and caramel notes.", 55.0),
+                new RetrievedProductContext("REVIEW", "Review #1 — rating 5/5", "Review text: sweet and smooth.", 25.0)
+        );
+
+        when(productInfoRepository.findById(productId)).thenReturn(Optional.of(product));
+        when(productReviewRepository.findAllByProductId(productId)).thenReturn(List.of());
+        when(productRagContextRetriever.retrieve(product, List.of(), "Is it sweet?"))
+                .thenReturn(retrievedContext);
+        when(productRagAiService.answer(org.mockito.ArgumentMatchers.anyString()))
+                .thenReturn("Yes. The retrieved context describes chocolate, caramel, and a sweet smooth cup.");
+
+        var response = service.ask(productId, "Is it sweet?");
+
+        assertThat(response.productId()).isEqualTo(productId);
+        assertThat(response.answer()).contains("sweet");
+        assertThat(response.sources()).hasSize(2);
+        assertThat(response.sources().getFirst().sourceLabel()).isEqualTo("Product details");
+    }
+
+    @Test
+    @DisplayName("ask: throws ProductNotFoundException when product does not exist")
+    void ask_missingProduct_throwsProductNotFoundException() {
+        var productId = UUID.randomUUID();
+        when(productInfoRepository.findById(productId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.ask(productId, "Tell me about it"))
+                .isInstanceOf(ProductNotFoundException.class)
+                .hasMessageContaining(productId.toString());
+    }
+}

--- a/src/test/java/com/zufar/icedlatte/ai/rag/ProductRagContextRetrieverTest.java
+++ b/src/test/java/com/zufar/icedlatte/ai/rag/ProductRagContextRetrieverTest.java
@@ -1,0 +1,84 @@
+package com.zufar.icedlatte.ai.rag;
+
+import com.zufar.icedlatte.product.entity.ProductInfo;
+import com.zufar.icedlatte.review.entity.ProductReview;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ProductRagContextRetriever unit tests")
+class ProductRagContextRetrieverTest {
+
+    private final ProductRagContextRetriever retriever = new ProductRagContextRetriever(3, 200);
+
+    @Test
+    @DisplayName("retrieve: prioritizes product contexts matching the user question")
+    void retrieve_matchingQuestion_prioritizesRelevantContexts() {
+        var product = buildProduct();
+        product.setAiSummary("Customers describe a smooth espresso with chocolate notes and very low acidity.");
+
+        var firstReview = new ProductReview();
+        firstReview.setProductRating(5);
+        firstReview.setLikesCount(7);
+        firstReview.setCreatedAt(OffsetDateTime.now());
+        firstReview.setText("Very chocolatey, smooth, and easy to drink.");
+
+        var secondReview = new ProductReview();
+        secondReview.setProductRating(3);
+        secondReview.setLikesCount(1);
+        secondReview.setCreatedAt(OffsetDateTime.now().minusDays(1));
+        secondReview.setText("More citrus than chocolate for my taste.");
+
+        var result = retriever.retrieve(product, List.of(firstReview, secondReview), "Does it taste chocolatey?");
+
+        assertThat(result).hasSize(3);
+        assertThat(result.getFirst().content().toLowerCase()).contains("chocolate");
+        assertThat(result).anyMatch(context -> context.sourceType().equals("PRODUCT_AI_SUMMARY"));
+    }
+
+    @Test
+    @DisplayName("retrieve: keeps result size within configured limit")
+    void retrieve_manyCandidates_respectsConfiguredLimit() {
+        var product = buildProduct();
+        product.setAiSummary("Balanced and sweet.");
+
+        var reviews = List.of(
+                review("Sweet and balanced", 4, 10),
+                review("Nutty aroma", 4, 9),
+                review("Low acidity", 5, 8),
+                review("Creamy body", 5, 7)
+        );
+
+        var result = retriever.retrieve(product, reviews, "Is it sweet?");
+
+        assertThat(result).hasSizeLessThanOrEqualTo(3);
+    }
+
+    private ProductInfo buildProduct() {
+        var product = new ProductInfo();
+        product.setId(UUID.randomUUID());
+        product.setName("Brazilian Espresso Beans");
+        product.setDescription("A rich medium roast with chocolate, caramel, and hazelnut notes.");
+        product.setBrandName("Iced Latte Roasters");
+        product.setSellerName("Iced Latte");
+        product.setOriginCountry("Brazil");
+        product.setAverageRating(new BigDecimal("4.7"));
+        product.setReviewsCount(24);
+        return product;
+    }
+
+    private ProductReview review(String text, int rating, int likes) {
+        var review = new ProductReview();
+        review.setText(text);
+        review.setProductRating(rating);
+        review.setLikesCount(likes);
+        review.setCreatedAt(OffsetDateTime.now());
+        return review;
+    }
+}


### PR DESCRIPTION
## Summary
- add a lightweight product-specific RAG slice in the backend
- expose a new endpoint to ask grounded questions about a single product
- retrieve context from product details, AI summary, and customer reviews before sending it to the model
- return both the final answer and the retrieved source snippets for transparency
- add unit tests for retrieval ranking and service orchestration
- add a docs page with request and response examples

## Why
The project already has AI integrations, but it does not yet have a retrieval-augmented generation flow that grounds answers in product data.

This PR adds a small learning-friendly first version of RAG without introducing extra infrastructure. It is intentionally product-scoped rather than a site-wide chatbot, which keeps the feature understandable and easy to evolve later.

## What was added
- `POST /api/v1/products/{productId}/rag/ask`
- retrieval over:
  - product description and metadata
  - product AI summary when available
  - product reviews
- ranked source snippets returned in the API response
- `docs/ai/product-rag.md`

## Notes
This first version is deliberately lightweight:
- no vector database
- no embeddings pipeline
- no frontend UI yet

That makes it a good base for a future follow-up PR with pgvector, embeddings, semantic search, or a frontend chat surface.

## Testing
- added `ProductRagContextRetrieverTest`
- added `DefaultProductRagServiceTest`
