### PR TITLE
fix: add human-readable validation message for password field (#270)

### DIFF
--- a/src/main/resources/api-specs/user-openapi.yaml
+++ b/src/main/resources/api-specs/user-openapi.yaml
@@ -543,6 +543,7 @@ components:
       minLength: 8
       maxLength: 128
       pattern: "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d@$!%*?&]{8,}$"
+      x-field-extra-annotation: '@jakarta.validation.constraints.Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d@$!%*?&]{8,}$", message = "Password must be at least 8 characters long and contain at least one letter, one digit, and may include special characters @$!%*?&.")'
 
     ChangeUserPasswordRequest:
       type: "object"


### PR DESCRIPTION
## Description
This PR addresses issue #270 by adding a user-friendly validation message for the password field in the OpenAPI specification. Previously, when a user entered an invalid password, the system would return the raw regex pattern as an error message, which is difficult for non-technical users to understand.

## Changes Made
- Modified `src/main/resources/api-specs/user-openapi.yaml`.
- Injected `x-field-extra-annotation` to include a custom `@Pattern` validation message in the generated DTOs.
- Kept the standard `pattern` property for documentation completeness while ensuring a clear error message is provided.

## How to Test
1. Run the application: `mvn spring-boot:run`.
2. Send a `PATCH` request to `/api/v1/users` with an invalid password format (e.g., "abcdefgh").
3. Verify that the response contains the human-readable message: "Password must be at least 8 characters long and contain at least one letter, one digit, and may include special characters @$!%*?&."

## Visual Proof

### A. Before Fix: Validation error showing raw regex pattern
<img width="987" height="731" alt="image" src="https://github.com/user-attachments/assets/71f0655b-1da5-46f9-80c3-65d34730465a" />

### B. After Fix: User-friendly validation message
<img width="986" height="727" alt="image" src="https://github.com/user-attachments/assets/d8e3562e-5cfd-477b-8546-15d99268c8b8" />

*(Please see the attached screenshot of the Postman response below)*

Closes #270
